### PR TITLE
Fix token costs, align graphs, and improve tmux pane

### DIFF
--- a/cmd/ccdash/main.go
+++ b/cmd/ccdash/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	version = "0.2.0"
+	version = "0.2.1"
 )
 
 func main() {

--- a/internal/metrics/tokens.go
+++ b/internal/metrics/tokens.go
@@ -418,13 +418,20 @@ func FormatTokens(count int64) string {
 	return string(result)
 }
 
-// FormatCost formats a cost value as currency
+// FormatCost formats a cost value as currency with comma separators
 func FormatCost(cost float64) string {
 	if cost == 0 {
 		return "$0.00"
 	}
 	if cost < 0.01 {
 		return fmt.Sprintf("$%.4f", cost)
+	}
+
+	// Format with commas for costs >= $1,000
+	if cost >= 1000 {
+		wholePart := int64(cost)
+		decimalPart := cost - float64(wholePart)
+		return fmt.Sprintf("$%s.%02d", FormatTokens(wholePart), int(decimalPart*100+0.5))
 	}
 	return fmt.Sprintf("$%.2f", cost)
 }

--- a/internal/metrics/tokens_test.go
+++ b/internal/metrics/tokens_test.go
@@ -46,7 +46,10 @@ func TestFormatCost(t *testing.T) {
 		{"very small", 0.0001, "$0.0001"},
 		{"cents", 0.42, "$0.42"},
 		{"dollars", 12.34, "$12.34"},
-		{"large", 1234.56, "$1234.56"},
+		{"hundreds", 999.99, "$999.99"},
+		{"large", 1234.56, "$1,234.56"},
+		{"thousands", 12345.67, "$12,345.67"},
+		{"millions", 1234567.89, "$1,234,567.89"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- Add comma separators to cost display for amounts >= $1,000
- Align CPU core bar graphs with consistent label width and fixed-width percentages
- Update tmux sessions panel to dynamically expand to 2 columns when sessions overflow
- Bump version to 0.2.1